### PR TITLE
[Kitsune] Added kit-plot to Kitsune utilities

### DIFF
--- a/Kitsune/utils/kit-plot
+++ b/Kitsune/utils/kit-plot
@@ -66,47 +66,36 @@ PLOT_LABELS = {
 }
 
 # All known benchmarks in kitsune-test-suite
-
 # If any benchmarks are added to `Kitsune/Benchmarks`, this list should be
 # updated
-
 BENCHMARKS = ["copy", "euler3d", "raytracer", "saxpy", "srad", "vecadd"]
 
 # All known metrics collected when building/running the kitsune-test-suite
-
 # If any additional metrics are collected, this list should be updated. In most
 # cases, it will also be necessary to add support for metric in
 # parse_and_plot_benchmark_data()
-
 METRICS = ["compile-time", "link-time", "total-runtime", "mean-runtime"]
 
 # All known benchmarks in kitsune-test-suite that have multiple kernels
-
 # If any multi-kernel benchmarks are added to `Kitsune/Benchmarks`, this list
 # should be updated
-
 MULTI_KERNEL_BENCHMARKS = ["euler3d", "srad"]
 
 # All known metrics collected from kernels in multi-kernel benchmarks when
 # building/running the kitsune-test-suite
-
 # If any additional metrics are collected, this list should be updated. In most
 # cases, it will also be necessary to add support for metric in
 # parse_and_plot_benchmark_data()
-
 MULTI_KERNEL_METRICS = ["total-runtime", "mean-runtime"]
 
 # All known targets that are suitible to act as baselines for normalizing
 # kitsune-test-suite data.
-
 # If any additional targets are suitable to be baselines, this list should be
 # update. Even if a report has data for more than one baseline target, only
 # one baseline will be selected for plotting
-
 BASELINE_TARGETS = ["kokkos-nvidia", "kokkos-amd"]
 
 # Figure width and height, in inches
-
 FIGURE_WIDTH = 9
 FIGURE_HEIGHT = 6
 
@@ -118,7 +107,10 @@ US_PER_SEC = 1000000
 # Parse the command line arguments. Returns the parsed object if parsing was
 # successful and will terminate the program with an error message otherwise
 def parse_command_line_args():
-    descr = "Generate plots from a Kitsune test suite report. This will overwrite any plot files currently in the save directory."
+    descr = (
+        "Generate plots from a Kitsune test suite report. This will "
+        "overwrite any plot files currently in the save directory."
+    )
     parser = ap.ArgumentParser(description=descr)
     parser.add_argument(
         "-e",
@@ -177,7 +169,9 @@ def parse_command_line_args():
     parser.add_argument(
         "--filter-extremes",
         action="store_true",
-        help="Subtract min and max values from total runtime data. Mean runtimes will also be recalulated from this new total and decreased count",
+        help="Subtract min and max values from total runtime data. Mean "
+        "runtimes will also be recalulated from this new total and decreased "
+        "count",
     )
     parser.add_argument(
         "--no-annotate",

--- a/Kitsune/utils/kit-plot
+++ b/Kitsune/utils/kit-plot
@@ -6,15 +6,17 @@ import matplotlib.pyplot as plt
 import numpy as np
 import os
 import sys
+import warnings
 
 # Despite representing data for different metrics, all the plots are the same
-# type of graph, so they can be generated the same way. However, the graph
+# type of graph, and they can be generated the same way. However, the graph
 # title, x and y labels, and file names should still be different for each
 # metric. This dictionary stores this information for each metric by using the
 # metric name as the key
-plot_labels = {
+# Tuple entries are of form (Title, Y-label, X-Label, Filename)
+PLOT_LABELS = {
     "compile-time": (
-        "Compilation Time Comparison",
+        "Total Compile Time Comparison",
         "Time (seconds)",
         "Benchmark Name",
         "compile-time.png",
@@ -38,43 +40,51 @@ plot_labels = {
         "mean-runtime.png",
     ),
     "euler3d-total-runtime": (
-        "Euler3d Kernel Performance Comparison: Total Runtime",
+        "Euler3d Total Runtime Comparison (Kernels)",
         "Total Runtime (seconds)",
         "Kernel Name",
-        "euler3d-kernel-total-rt.png",
+        "euler3d-kernel-total-runtime.png",
     ),
     "srad-total-runtime": (
-        "Srad Kernel Performance Comparison: Total Runtime",
+        "Srad Total Runtime Comparison (Kernels)",
         "Total Runtime (seconds)",
         "Kernel Name",
-        "srad-kernel-total-rt.png",
+        "srad-kernel-total-runtime.png",
     ),
     "euler3d-mean-runtime": (
-        "Euler3d Kernel Performance Comparison: Mean Runtime",
+        "Euler3d Mean Runtime Comparison (Kernels)",
         "Mean Runtime (seconds)",
         "Kernel Name",
-        "euler3d-kernel-mean-rt.png",
+        "euler3d-kernel-mean-runtime.png",
     ),
     "srad-mean-runtime": (
-        "Srad Kernel Performance Comparison: Mean Runtime",
+        "Srad Mean Runtime Comparison (Kernels)",
         "Mean Runtime (seconds)",
         "Kernel Name",
-        "srad-kernel-mean-rt.png",
+        "srad-kernel-mean-runtime.png",
     ),
 }
 
+BENCHMARK_OPTIONS = ["copy", "euler3d", "raytracer", "saxpy", "srad", "vecadd"]
+METRIC_OPTIONS = ["compile-time", "link-time", "total-runtime", "mean-runtime"]
+
+MULTI_KERNEL_BENCHMARKS = ["euler3d", "srad"]
+MULTI_KERNEL_METRICS = ["total-runtime", "mean-runtime"]
+
+BASELINE_TARGETS = ["kokkos-nvidia", "kokkos-amd"]
+
+ERROR_BAR_CAP_SIZE = 5
+
+FIGURE_WIDTH = 9
+FIGURE_HEIGHT = 6
+
+US_PER_SEC = 1000000
 
 # Parse the command line arguments. Returns the parsed object if parsing was
 # successful and will terminate the program with an error message otherwise
 def parse_command_line_args():
-    prog = "plotter"
-    descr = "Generate plots from Kitsune test suite report. Will overwrite any plot files currently in save directory."
-
-    # TODO: fix help message formatting so that wrapped help message text
-    #       gets indented
-    parser = ap.ArgumentParser(
-        prog=prog, description=descr, formatter_class=ap.RawTextHelpFormatter
-    )
+    descr = "Generate plots from a Kitsune test suite report. This will overwrite any plot files currently in the save directory."
+    parser = ap.ArgumentParser(description=descr)
     parser.add_argument(
         "-e",
         "--error-bars",
@@ -86,80 +96,113 @@ def parse_command_line_args():
         "-k",
         "--kernel-plots",
         action="store_true",
-        help="When used, plots mean kernel runtime plots for benchmarks "
-        "with multiple kernels: euler3d, srad",
+        help="When used, plots runtime metrics for benchmarks with multiple "
+        "kernels: " + ', '.join(MULTI_KERNEL_BENCHMARKS),
     )
     parser.add_argument(
         "-s",
         "--save-dir",
         metavar="<path>",
-        help="Path to directory where you would like to save plots (default:"
-        " save to current directory)",
+        help="Path to directory where you would like to save plots (default: "
+        "save to current directory)",
     )
-    # TODO: parsing the arguments into a list like this is very clean, but it
-    #       creates a problem if positional argument (report) is put at the
-    #       end of command because it gets wrapped up by nargs choice
     parser.add_argument(
         "--benchmarks",
-        metavar="BENCHMARK",
-        nargs="+",
         type=str,
-        choices=["copy", "euler3d", "raytracer", "saxpy", "srad", "vecadd"],
-        default=["copy", "euler3d", "raytracer", "saxpy", "srad", "vecadd"],
-        help="List of benchmarks to include in plots. "
-        "If bechmarks are not specified, data from all possible "
-        "benchmarks will be plotted\n"
-        "options: copy, euler3d, raytracer, saxpy, srad, vecadd",
+        nargs="+",
+        choices=BENCHMARK_OPTIONS,
+        default=BENCHMARK_OPTIONS,
+        help="List of benchmarks to include in plots. If benchmarks are not "
+        "specified, data from all known benchmarks will be plotted",
     )
     parser.add_argument(
         "--metrics",
         type=str,
-        metavar="METRIC",
         nargs="+",
-        choices=["compile-time", "link-time", "total-runtime", "mean-runtime"],
-        default=["compile-time", "link-time", "total-runtime", "mean-runtime"],
-        help="List of metrics to generate plots for. "
-        "If metrics flag is not specified, plots for all possible "
-        "metrics will be generated\n"
-        "options: compile-time, link-time, total-runtime, "
-        "mean-runtime",
+        choices=METRIC_OPTIONS,
+        default=METRIC_OPTIONS,
+        help="List of metrics to generate plots for. If this option is not "
+        "specified, plots for all known metrics will be generated",
     )
     parser.add_argument(
         "--targets",
         type=str,
         metavar="TARGET",
         nargs="+",
-        help="List of targets to include in plots. "
-        "If metrics flag is not specified, plots using all possible "
-        "targets will be generated\n"
-        "options are based on your architecture, use --print-targets "
-        "to print options",
+        help="List of targets to include in plots. If this option is not "
+        "specified, plots using all known targets will be generated. Use "
+        "--print-targets to print options",
+    )
+    parser.add_argument(
+        "--image_dpi",
+        metavar="<int>",
+        default=300,
+        help="Value to be used for dpi of saved images",
+    )
+    parser.add_argument(
+        "--filter_extremes",
+        action="store_true",
+        help="Subtract min and max values from total runtime data. Mean runtimes will also be recalulated from this new total and decreased count",
     )
     parser.add_argument(
         "--no-annotate",
-        action="store_false",
-        help="Enable y-value annotations above data bars",
+        action="store_true",
+        help="Do not include y-value annotations above data bars",
     )
     parser.add_argument(
-        "--no-baseline", action="store_true", help="Turn off baseline mode for plots"
+        "--no-baseline",
+        action="store_true",
+        help="Do not process data with a baseline target. Instead, plots will "
+        "use raw data"
     )
     parser.add_argument(
         "--no-metadata",
         action="store_false",
-        help="Turns metadata caption with date/time and GPU info off",
+        help="Do not generate the caption containing metadata such as date, "
+        "time, GPU model etc.",
     )
     parser.add_argument(
         "--print-targets",
         action="store_true",
-        help="If this flag is used, no plots will be generated. Instead a "
-        "list of targets in provided report will be printed",
+        help="Print the list of targets present in the report. Do not generate "
+        "any plots",
     )
     parser.add_argument(
-        "report", type=str, metavar="<file>", help="Path to .json report file"
+        "report",
+        type=str,
+        metavar="<file>",
+        help="Path to .json report file. Note: if this argument is placed "
+        "immediately after one of the benchmarks, metrics, or targets "
+        "options, a -- must be placed in between (eg. --benchmarks ... "
+        "-- /path/to/report.json)"
     )
 
     return parser.parse_args()
 
+def get_baseline(data):
+    for potential_baseline in data:
+        if potential_baseline in BASELINE_TARGETS:
+            return potential_baseline
+
+    sys.exit("Error: No suitable baseline found. Targets eligible to be a "
+             "baseline: " + ', '.join(BASELINE_TARGETS))
+
+def process_error_ranges(args, values, metric, target_name):
+    error_mins = np.array([])
+    error_maxs = np.array([])
+    # Similar idea to how the raw data is processed, but the resulting list
+    # needs to be split further since each entry in error_bars is a tuple of min
+    # and max values for that benchmark. To plot, mins and maxs need to be in
+    # seperate lists, rather than grouped together as in the raw data
+    errs = [
+            args.error_bars_data[metric][target_name][k]
+            for k in sorted(args.error_bars_data[metric][target_name].keys())
+           ]
+    for i, error_range in enumerate(errs):
+        error_mins = np.append(error_mins, values[i] - error_range[0])
+        error_maxs = np.append(error_maxs, error_range[1] - values[i])
+
+    return np.array([error_mins, error_maxs])
 
 def generate_plot(args, data, metric):
     # These values are used to set up bar positions and width
@@ -168,56 +211,58 @@ def generate_plot(args, data, metric):
     x = np.arange(len(benchmark_names))
     width = 0.8 * (1 / num_targets)
 
-    fig, ax = plt.subplots(figsize=(9, 6))
+    fig, ax = plt.subplots(figsize=(FIGURE_WIDTH, FIGURE_HEIGHT))
 
     # Collect baseline data for plots
     if not args.no_baseline:
-        possible_baselines = ["kokkos-nvidia", "kokkos-amd"]
-        # TODO: I feel like there should be a better way of doing this but if
-        #       there is, I can't think of it right now
-        if possible_baselines[0] in data:
-            baseline = possible_baselines[0]
-        elif possible_baselines[1] in data:
-            baseline = possible_baselines[1]
-        else:
-            sys.exit("Could not find baseline target (kokkos-nvidia or kokkos-amd)")
+        baseline = get_baseline(data)
+        # The benchmarks are not added to the report in alphabetical order. In
+        # practice, this does not really matter because it only affects the
+        # order of the benchmarks along the x axis. However, the plots look a
+        # bit cleaner when sorted alphabetically
         baseline_data = np.array(
             [data[baseline][k] for k in sorted(data[baseline].keys())]
         )
+        if args.error_bars and metric in args.error_bars_data:
+            baseline_error_ranges = process_error_ranges(args, baseline_data, metric, baseline)
 
     for index, target_name in enumerate(sorted(data.keys())):
-        # This is somewhat convoluted.
-        # The benchmarks are not run in alphabetical order. In practice, this
-        # does not really matter because it only affects the order of the
-        # benchmarks along the x axis. However, the plots look a bit cleaner
-        # when sorted alphabetically
-        annotate_vals = np.array(
+        raw_values = np.array(
             [data[target_name][k] for k in sorted(data[target_name].keys())]
         )
 
         if not args.no_baseline:
-            vals = baseline_data / annotate_vals
+            # TODO: I am not sure if suppressing the warnings like this is
+            #       actually a good idea. As mentioned in my comment below, the
+            #       way Python handles divide by zeros is very convenient. Now,
+            #       if a user sees a bunch of divide by zero warnings, they
+            #       might worry. But because the plots look the way we want them
+            #       to, this worry would be completely unneccesary. That being
+            #       said there could be a different possible runtime warning
+            #       that I am unaware of which will now never be seen
+
+            # In the event that a report is missing data for a benchmark, a
+            # default value of 0 is used. But of course, dividing by 0 is
+            # illegal, so when one tries to divide by 0, Python will emit a
+            # runtime warning, and store a value of "inf". For bar plots, when
+            # matplotlib encounters an inf, it will simply omit that bar.
+            # Conveniently, this is the desired behavior for the test suite
+            # plots. So, to prevent unnessecary panic, these runtime warnings
+            # are temporarily suppressed
+            warnings.filterwarnings("ignore", category=RuntimeWarning)
+            values = baseline_data / raw_values
+            warnings.resetwarnings()
         else:
-            vals = annotate_vals
+            values = raw_values
 
-        if args.no_baseline and metric in args.error_bars_data:
-            error_mins = []
-            error_maxs = []
-            # Similar idea to vals, but the resulting list needs to be split
-            # further since each entry in error_bars is a list of min and max
-            # values for that benchmark. To plot, mins and maxs need to be in
-            # seperate lists, rather than grouped together as in the raw data
-            errs = np.array(
-                [
-                    args.error_bars_data[metric][target_name][k]
-                    for k in sorted(args.error_bars_data[metric][target_name].keys())
-                ]
-            )
-            for i, error_range in enumerate(errs):
-                error_mins.append(vals[i] - error_range[0])
-                error_maxs.append(error_range[1] - vals[i])
-
-            error_ranges = [error_mins, error_maxs]
+        if args.error_bars and metric in args.error_bars_data:
+            error_ranges = process_error_ranges(args, raw_values, metric, target_name)
+            if not args.no_baseline:
+                # Again, suppress divide by zero warnings in the event of
+                # missing data
+                warnings.filterwarnings("ignore", category=RuntimeWarning)
+                error_ranges = baseline_error_ranges / error_ranges
+                warnings.resetwarnings()
         else:
             error_ranges = None
 
@@ -225,20 +270,20 @@ def generate_plot(args, data, metric):
         # the x position of the center of the bar
         bars = ax.bar(
             x + (index + 0.5 * (1 - num_targets)) * width,
-            vals,
+            values,
             width,
             label=target_name,
             zorder=3,
             yerr=error_ranges,
-            capsize=5,
+            capsize=ERROR_BAR_CAP_SIZE,
         )
 
         # Annotate each bar with its y value if enabled
-        if args.no_annotate:
+        if not args.no_annotate:
             for i, bar in enumerate(bars):
                 height = bar.get_height()
                 ax.annotate(
-                    f"{annotate_vals[i]:.2f}",
+                    f"{raw_values[i]:.2f}",
                     xy=(bar.get_x() + bar.get_width() / 2, height),
                     xytext=(0, 3),
                     textcoords="offset points",
@@ -248,7 +293,7 @@ def generate_plot(args, data, metric):
                 )
 
     # Get names/labels and format plot
-    title, ylabel, xlabel, filename = plot_labels[metric]
+    title, ylabel, xlabel, filename = PLOT_LABELS[metric]
     if not args.no_baseline:
         ylabel = "Speedup over kokkos (higher is better)"
     if args.save_dir:
@@ -269,13 +314,20 @@ def generate_plot(args, data, metric):
 
     # Clean up the layout and save
     fig.tight_layout()
-    plt.savefig(filename, dpi=300)
-
+    plt.savefig(filename, dpi=args.image_dpi)
 
 def parse_and_plot_benchmark_data(args, json_data):
-    # If no targets are provided, use whatever targets are in the report
+    # If no targets are provided, use whatever targets are in the report.
+    # Otherwise, verify that there is data for all user provided targets in the
+    # report
     if not args.targets:
         args.targets = json_data["targets"]
+    else:
+        missing_targets = [target for target in args.targets
+                           if target not in json_data["targets"]]
+        if missing_targets:
+            sys.exit("Error: There is no data in provided report for the following targets: " + ', '.join(missing_targets))
+
 
     if args.error_bars:
         args.error_bars_data = {
@@ -288,13 +340,11 @@ def parse_and_plot_benchmark_data(args, json_data):
     # names are of form: benchmark-metric (e.g. euler3d-total-runtime)
     enabled_kernel_metrics = []
     if args.kernel_plots:
-        multi_kernel_benchmarks = ["euler3d", "srad"]
-        multi_kernel_metrics = ["total-runtime", "mean-runtime"]
-        for benchmark in [b for b in args.benchmarks if b in multi_kernel_benchmarks]:
+        for benchmark in [b for b in args.benchmarks if b in MULTI_KERNEL_BENCHMARKS]:
             enabled_kernel_metrics += [
                 (benchmark + "-" + metric)
                 for metric in args.metrics
-                if metric in multi_kernel_metrics
+                if metric in MULTI_KERNEL_METRICS
             ]
 
     plot_data = {}
@@ -315,26 +365,48 @@ def parse_and_plot_benchmark_data(args, json_data):
                     plot_data[metric_name][target_name] = {}
                     if args.error_bars:
                         args.error_bars_data["mean-runtime"][target_name] = {}
-
-                if metric_name in target:
-                    val = target[metric_name]
+                if target["code"] == "fail":
+                    print(
+                        f"Warning: no test data for {target_name} {benchmark_name}. Bar will be omited from {metric_name} plot",
+                        file=sys.stderr,
+                    )
+                    value = 0
+                    if args.error_bars and metric_name == "mean-runtime":
+                        args.error_bars_data[metric_name][target_name][
+                            benchmark_name
+                        ] = (0, 0)
+                elif metric_name in target:
+                    value = target[metric_name]
                 elif metric_name == "total-runtime":
-                    val = target["times"]["total"]["total"]
+                    value = target["times"]["total"]["total"]
+                    if args.filter_extremes and target["times"]["total"]["count"] != 2:
+                        value -= target["times"]["total"]["max"]
+                        value -= target["times"]["total"]["min"]
+                elif metric_name == "mean-runtime" and args.filter_extremes and target["times"]["total"]["count"] != 2:
+                    total = target["times"]["total"]["total"]
+                    total -= target["times"]["total"]["max"]
+                    total -= target["times"]["total"]["min"]
+                    value = total / (target["times"]["total"]["count"] - 2)
                 elif metric_name == "mean-runtime":
-                    val = target["times"]["total"]["mean"]
+                    value = target["times"]["total"]["mean"]
                     if args.error_bars:
-                        rt_min = target["times"]["total"]["min"] / 1000000
-                        rt_max = target["times"]["total"]["max"] / 1000000
+                        rt_min = target["times"]["total"]["min"] / US_PER_SEC
+                        rt_max = target["times"]["total"]["max"] / US_PER_SEC
                         args.error_bars_data[metric_name][target_name][
                             benchmark_name
                         ] = (rt_min, rt_max)
                 # Convert from microseconds to seconds
-                # TODO: cl arg to set units?
-                plot_data[metric_name][target_name][benchmark_name] = val / 1000000
+                plot_data[metric_name][target_name][benchmark_name] = value / US_PER_SEC
 
             # Collect data for plots comparing kernel performance
             for metric_name in enabled_kernel_metrics:
                 if benchmark_name not in metric_name:
+                    continue
+                if target["code"] == "fail":
+                    print(
+                        f"Warning: no kernel data for {target_name} {benchmark_name}. Skipping target for {metric_name} plot",
+                        file=sys.stderr,
+                    )
                     continue
                 if target_name not in plot_data[metric_name]:
                     plot_data[metric_name][target_name] = {}
@@ -344,16 +416,24 @@ def parse_and_plot_benchmark_data(args, json_data):
                     kernel = target["times"][kernel_name]
                     if kernel["count"] != 1:
                         if "total-runtime" in metric_name:
-                            val = kernel["total"]
+                            value = kernel["total"]
+                            if args.filter_extremes and kernel["count"] != 2:
+                                value -= kernel["max"]
+                                value -= kernel["min"]
+                        elif metric_name == "mean-runtime" and args.filter_extremes and kernel["count"] != 2:
+                            total = kernel["total"]
+                            total -= kernel["max"]
+                            total -= kernel["min"]
+                            value = total / (kernel["count"] - 2)
                         elif "mean-runtime" in metric_name:
-                            val = kernel["mean"]
+                            value = kernel["mean"]
                             if args.error_bars:
-                                rt_min = kernel["min"] / 1000000
-                                rt_max = kernel["max"] / 1000000
+                                rt_min = kernel["min"] / US_PER_SEC
+                                rt_max = kernel["max"] / US_PER_SEC
                                 args.error_bars_data[metric_name][target_name][
                                     kernel_name
                                 ] = (rt_min, rt_max)
-                        plot_data[metric_name][target_name][kernel_name] = val / 1000000
+                        plot_data[metric_name][target_name][kernel_name] = value / US_PER_SEC
 
     # Generate all requested plots
     for metric, data in plot_data.items():
@@ -366,23 +446,25 @@ def main():
     args = parse_command_line_args()
 
     if not os.path.exists(args.report):
-        sys.exit(f"Could not find report: {args.report}")
+        sys.exit(f"Error: Could not find report: {args.report}")
 
     if args.save_dir and not os.path.isdir(args.save_dir):
-        sys.exit(f"Could not find directory: {args.save_dir}")
+        sys.exit(f"Error: Could not find directory: {args.save_dir}")
 
-    if args.error_bars and not args.no_baseline:
+    if args.error_bars and args.filter_extremes:
         print(
             "Warning: Error bars were enabled but it is not possible to "
-            "include error bars on plots scaled by a baseline. Generated "
-            "plots will not have error bars"
+            "include error bars when removing extremes from data. Generated "
+            "plots will not have error bars",
+            file=sys.stderr,
         )
-
+        args.error_bars = False
     if args.error_bars and not args.no_annotate:
         print(
             "Warning: It is not recommended to include both error bars and "
             "annotations in one plot since the two features overlap and may "
-            "look somewhat messy"
+            "look somewhat messy",
+            file=sys.stderr,
         )
 
     with open(args.report, "r") as file:
@@ -394,7 +476,7 @@ def main():
         return 0
 
     if not json_data["tests"]:
-        sys.exit("Provided report does have test data")
+        sys.exit("Error: Provided report does have test data")
 
     parse_and_plot_benchmark_data(args, json_data)
 

--- a/Kitsune/utils/kit-plot
+++ b/Kitsune/utils/kit-plot
@@ -68,7 +68,7 @@ plot_labels = {
 # successful and will terminate the program with an error message otherwise
 def parse_command_line_args():
     prog = "plotter"
-    descr = "Generate plots from Kitsune test suite report."
+    descr = "Generate plots from Kitsune test suite report. Will overwrite any plot files currently in save directory."
 
     # TODO: fix help message formatting so that wrapped help message text
     #       gets indented

--- a/Kitsune/utils/kit-plot
+++ b/Kitsune/utils/kit-plot
@@ -13,7 +13,7 @@ import warnings
 # title, x and y labels, and file names should still be different for each
 # metric. This dictionary stores this information for each metric by using the
 # metric name as the key
-# Tuple entries are of form (Title, Y-label, X-Label, Filename)
+# Tuple entries are of the form (Title, Y-label, X-Label, Filename)
 PLOT_LABELS = {
     "compile-time": (
         "Total Compile Time Comparison",
@@ -65,20 +65,55 @@ PLOT_LABELS = {
     ),
 }
 
-BENCHMARK_OPTIONS = ["copy", "euler3d", "raytracer", "saxpy", "srad", "vecadd"]
-METRIC_OPTIONS = ["compile-time", "link-time", "total-runtime", "mean-runtime"]
+# All known benchmarks in kitsune-test-suite
+
+# If any benchmarks are added to `Kitsune/Benchmarks`, this list should be
+# updated
+
+BENCHMARKS = ["copy", "euler3d", "raytracer", "saxpy", "srad", "vecadd"]
+
+# All known metrics collected when building/running the kitsune-test-suite
+
+# If any additional metrics are collected, this list should be updated. In most
+# cases, it will also be necessary to add support for metric in
+# parse_and_plot_benchmark_data()
+
+METRICS = ["compile-time", "link-time", "total-runtime", "mean-runtime"]
+
+# All known benchmarks in kitsune-test-suite that have multiple kernels
+
+# If any multi-kernel benchmarks are added to `Kitsune/Benchmarks`, this list
+# should be updated
 
 MULTI_KERNEL_BENCHMARKS = ["euler3d", "srad"]
+
+# All known metrics collected from kernels in multi-kernel benchmarks when
+# building/running the kitsune-test-suite
+
+# If any additional metrics are collected, this list should be updated. In most
+# cases, it will also be necessary to add support for metric in
+# parse_and_plot_benchmark_data()
+
 MULTI_KERNEL_METRICS = ["total-runtime", "mean-runtime"]
+
+# All known targets that are suitible to act as baselines for normalizing
+# kitsune-test-suite data.
+
+# If any additional targets are suitable to be baselines, this list should be
+# update. Even if a report has data for more than one baseline target, only
+# one baseline will be selected for plotting
 
 BASELINE_TARGETS = ["kokkos-nvidia", "kokkos-amd"]
 
-ERROR_BAR_CAP_SIZE = 5
+# Figure width and height, in inches
 
 FIGURE_WIDTH = 9
 FIGURE_HEIGHT = 6
 
+ERROR_BAR_CAP_SIZE = 5
+
 US_PER_SEC = 1000000
+
 
 # Parse the command line arguments. Returns the parsed object if parsing was
 # successful and will terminate the program with an error message otherwise
@@ -97,7 +132,7 @@ def parse_command_line_args():
         "--kernel-plots",
         action="store_true",
         help="When used, plots runtime metrics for benchmarks with multiple "
-        "kernels: " + ', '.join(MULTI_KERNEL_BENCHMARKS),
+        "kernels: " + ", ".join(MULTI_KERNEL_BENCHMARKS),
     )
     parser.add_argument(
         "-s",
@@ -110,8 +145,8 @@ def parse_command_line_args():
         "--benchmarks",
         type=str,
         nargs="+",
-        choices=BENCHMARK_OPTIONS,
-        default=BENCHMARK_OPTIONS,
+        choices=BENCHMARKS,
+        default=BENCHMARKS,
         help="List of benchmarks to include in plots. If benchmarks are not "
         "specified, data from all known benchmarks will be plotted",
     )
@@ -119,8 +154,8 @@ def parse_command_line_args():
         "--metrics",
         type=str,
         nargs="+",
-        choices=METRIC_OPTIONS,
-        default=METRIC_OPTIONS,
+        choices=METRICS,
+        default=METRICS,
         help="List of metrics to generate plots for. If this option is not "
         "specified, plots for all known metrics will be generated",
     )
@@ -134,13 +169,13 @@ def parse_command_line_args():
         "--print-targets to print options",
     )
     parser.add_argument(
-        "--image_dpi",
+        "--image-dpi",
         metavar="<int>",
         default=300,
         help="Value to be used for dpi of saved images",
     )
     parser.add_argument(
-        "--filter_extremes",
+        "--filter-extremes",
         action="store_true",
         help="Subtract min and max values from total runtime data. Mean runtimes will also be recalulated from this new total and decreased count",
     )
@@ -152,8 +187,8 @@ def parse_command_line_args():
     parser.add_argument(
         "--no-baseline",
         action="store_true",
-        help="Do not process data with a baseline target. Instead, plots will "
-        "use raw data"
+        help="Do not normalize metrics to a baseline when plotting. Instead, "
+        "use absoulte values of the metrics",
     )
     parser.add_argument(
         "--no-metadata",
@@ -172,37 +207,23 @@ def parse_command_line_args():
         type=str,
         metavar="<file>",
         help="Path to .json report file. Note: if this argument is placed "
-        "immediately after one of the benchmarks, metrics, or targets "
-        "options, a -- must be placed in between (eg. --benchmarks ... "
-        "-- /path/to/report.json)"
+        "immediately after one of --benchmarks, --metrics, or --targets, '--' "
+        "must be added before <file> (eg. --benchmarks euler srad -- "
+        "/path/to/report.json)",
     )
 
     return parser.parse_args()
+
 
 def get_baseline(data):
     for potential_baseline in data:
         if potential_baseline in BASELINE_TARGETS:
             return potential_baseline
+    sys.exit(
+        "Error: No suitable baseline found. Targets eligible to be a "
+        "baseline: " + ", ".join(BASELINE_TARGETS)
+    )
 
-    sys.exit("Error: No suitable baseline found. Targets eligible to be a "
-             "baseline: " + ', '.join(BASELINE_TARGETS))
-
-def process_error_ranges(args, values, metric, target_name):
-    error_mins = np.array([])
-    error_maxs = np.array([])
-    # Similar idea to how the raw data is processed, but the resulting list
-    # needs to be split further since each entry in error_bars is a tuple of min
-    # and max values for that benchmark. To plot, mins and maxs need to be in
-    # seperate lists, rather than grouped together as in the raw data
-    errs = [
-            args.error_bars_data[metric][target_name][k]
-            for k in sorted(args.error_bars_data[metric][target_name].keys())
-           ]
-    for i, error_range in enumerate(errs):
-        error_mins = np.append(error_mins, values[i] - error_range[0])
-        error_maxs = np.append(error_maxs, error_range[1] - values[i])
-
-    return np.array([error_mins, error_maxs])
 
 def generate_plot(args, data, metric):
     # These values are used to set up bar positions and width
@@ -223,8 +244,6 @@ def generate_plot(args, data, metric):
         baseline_data = np.array(
             [data[baseline][k] for k in sorted(data[baseline].keys())]
         )
-        if args.error_bars and metric in args.error_bars_data:
-            baseline_error_ranges = process_error_ranges(args, baseline_data, metric, baseline)
 
     for index, target_name in enumerate(sorted(data.keys())):
         raw_values = np.array(
@@ -232,42 +251,55 @@ def generate_plot(args, data, metric):
         )
 
         if not args.no_baseline:
-            # TODO: I am not sure if suppressing the warnings like this is
-            #       actually a good idea. As mentioned in my comment below, the
-            #       way Python handles divide by zeros is very convenient. Now,
-            #       if a user sees a bunch of divide by zero warnings, they
-            #       might worry. But because the plots look the way we want them
-            #       to, this worry would be completely unneccesary. That being
-            #       said there could be a different possible runtime warning
-            #       that I am unaware of which will now never be seen
-
-            # In the event that a report is missing data for a benchmark, a
-            # default value of 0 is used. But of course, dividing by 0 is
-            # illegal, so when one tries to divide by 0, Python will emit a
-            # runtime warning, and store a value of "inf". For bar plots, when
-            # matplotlib encounters an inf, it will simply omit that bar.
-            # Conveniently, this is the desired behavior for the test suite
-            # plots. So, to prevent unnessecary panic, these runtime warnings
-            # are temporarily suppressed
-            warnings.filterwarnings("ignore", category=RuntimeWarning)
-            values = baseline_data / raw_values
-            warnings.resetwarnings()
+            values = np.divide(
+                baseline_data,
+                raw_values,
+                out=np.zeros_like(baseline_data),
+                where=raw_values != 0,
+            )
         else:
             values = raw_values
 
         if args.error_bars and metric in args.error_bars_data:
-            error_ranges = process_error_ranges(args, raw_values, metric, target_name)
+            # Similar idea to how the raw data is processed, but the resulting
+            # list needs to be split further since each entry in error_bars is a
+            # tuple of min and max values for that benchmark. To plot, mins and
+            # maxs need to be in seperate lists, rather than grouped together as
+            # in the raw data
+            errs = [
+                args.error_bars_data[metric][target_name][k]
+                for k in sorted(args.error_bars_data[metric][target_name].keys())
+            ]
+
+            mins = np.array([error_range[0] for error_range in errs])
+            maxs = np.array([error_range[1] for error_range in errs])
             if not args.no_baseline:
-                # Again, suppress divide by zero warnings in the event of
-                # missing data
-                warnings.filterwarnings("ignore", category=RuntimeWarning)
-                error_ranges = baseline_error_ranges / error_ranges
-                warnings.resetwarnings()
+                new_mins = np.divide(
+                    baseline_data,
+                    mins,
+                    out=np.zeros_like(baseline_data),
+                    where=mins != 0,
+                )
+                new_maxs = np.divide(
+                    baseline_data,
+                    maxs,
+                    out=np.zeros_like(baseline_data),
+                    where=maxs != 0,
+                )
+                # When the baseline data is divided by the extremes, they swap.
+                # For example, since the minimum times are faster times, when
+                # normalized to a baseline, they represent a larger speedup than
+                # the mean (and the inverse for the maximums). So, the new maxs
+                # become the lower bounds of the error bars, and the new mins
+                # become the upper bounds
+                error_ranges = np.array([values - new_maxs, new_mins - values])
+            else:
+                error_ranges = np.array([values - mins, maxs - values])
         else:
             error_ranges = None
 
-        # Bars are added to the plot, using index, width, and x to determine
-        # the x position of the center of the bar
+        # Bars are added to the plot, using index, width, and x to determine the
+        # x position of the center of the bar
         bars = ax.bar(
             x + (index + 0.5 * (1 - num_targets)) * width,
             values,
@@ -316,6 +348,7 @@ def generate_plot(args, data, metric):
     fig.tight_layout()
     plt.savefig(filename, dpi=args.image_dpi)
 
+
 def parse_and_plot_benchmark_data(args, json_data):
     # If no targets are provided, use whatever targets are in the report.
     # Otherwise, verify that there is data for all user provided targets in the
@@ -323,11 +356,14 @@ def parse_and_plot_benchmark_data(args, json_data):
     if not args.targets:
         args.targets = json_data["targets"]
     else:
-        missing_targets = [target for target in args.targets
-                           if target not in json_data["targets"]]
+        missing_targets = [
+            target for target in args.targets if target not in json_data["targets"]
+        ]
         if missing_targets:
-            sys.exit("Error: There is no data in provided report for the following targets: " + ', '.join(missing_targets))
-
+            sys.exit(
+                "Error: There is no data in the report for the following "
+                "targets: " + ", ".join(missing_targets)
+            )
 
     if args.error_bars:
         args.error_bars_data = {
@@ -361,13 +397,14 @@ def parse_and_plot_benchmark_data(args, json_data):
                 continue
             # Collect data for plots comparing different benchmarks
             for metric_name in args.metrics:
-                if target_name not in plot_data[metric_name]:
-                    plot_data[metric_name][target_name] = {}
-                    if args.error_bars:
-                        args.error_bars_data["mean-runtime"][target_name] = {}
-                if target["code"] == "fail":
+                plot_data[metric_name].setdefault(target_name, {})
+                if args.error_bars:
+                    args.error_bars_data["mean-runtime"].setdefault(target_name, {})
+                if target["code"] == "fail" or target["code"] == "noexe":
                     print(
-                        f"Warning: no test data for {target_name} {benchmark_name}. Bar will be omited from {metric_name} plot",
+                        f"Warning: no test data for {target_name} "
+                        f"{benchmark_name}. Bar will be omited from "
+                        f"{metric_name} plot",
                         file=sys.stderr,
                     )
                     value = 0
@@ -379,10 +416,14 @@ def parse_and_plot_benchmark_data(args, json_data):
                     value = target[metric_name]
                 elif metric_name == "total-runtime":
                     value = target["times"]["total"]["total"]
-                    if args.filter_extremes and target["times"]["total"]["count"] != 2:
+                    if args.filter_extremes and target["times"]["total"]["count"] > 2:
                         value -= target["times"]["total"]["max"]
                         value -= target["times"]["total"]["min"]
-                elif metric_name == "mean-runtime" and args.filter_extremes and target["times"]["total"]["count"] != 2:
+                elif (
+                    metric_name == "mean-runtime"
+                    and args.filter_extremes
+                    and target["times"]["total"]["count"] > 2
+                ):
                     total = target["times"]["total"]["total"]
                     total -= target["times"]["total"]["max"]
                     total -= target["times"]["total"]["min"]
@@ -395,6 +436,8 @@ def parse_and_plot_benchmark_data(args, json_data):
                         args.error_bars_data[metric_name][target_name][
                             benchmark_name
                         ] = (rt_min, rt_max)
+                # If more metrics are added, this is where to add support
+
                 # Convert from microseconds to seconds
                 plot_data[metric_name][target_name][benchmark_name] = value / US_PER_SEC
 
@@ -402,9 +445,11 @@ def parse_and_plot_benchmark_data(args, json_data):
             for metric_name in enabled_kernel_metrics:
                 if benchmark_name not in metric_name:
                     continue
-                if target["code"] == "fail":
+                if target["code"] == "fail" or target["code"] == "noexe":
                     print(
-                        f"Warning: no kernel data for {target_name} {benchmark_name}. Skipping target for {metric_name} plot",
+                        f"Warning: no kernel data for {target_name} "
+                        f"{benchmark_name}. Skipping {target_name} in "
+                        f"{metric_name} plot",
                         file=sys.stderr,
                     )
                     continue
@@ -417,10 +462,14 @@ def parse_and_plot_benchmark_data(args, json_data):
                     if kernel["count"] != 1:
                         if "total-runtime" in metric_name:
                             value = kernel["total"]
-                            if args.filter_extremes and kernel["count"] != 2:
+                            if args.filter_extremes and kernel["count"] > 2:
                                 value -= kernel["max"]
                                 value -= kernel["min"]
-                        elif metric_name == "mean-runtime" and args.filter_extremes and kernel["count"] != 2:
+                        elif (
+                            metric_name == "mean-runtime"
+                            and args.filter_extremes
+                            and kernel["count"] > 2
+                        ):
                             total = kernel["total"]
                             total -= kernel["max"]
                             total -= kernel["min"]
@@ -433,7 +482,12 @@ def parse_and_plot_benchmark_data(args, json_data):
                                 args.error_bars_data[metric_name][target_name][
                                     kernel_name
                                 ] = (rt_min, rt_max)
-                        plot_data[metric_name][target_name][kernel_name] = value / US_PER_SEC
+                        # If more multi-kernel metrics are added, this is where
+                        # to add support
+
+                        plot_data[metric_name][target_name][kernel_name] = (
+                            value / US_PER_SEC
+                        )
 
     # Generate all requested plots
     for metric, data in plot_data.items():

--- a/Kitsune/utils/kit-plot
+++ b/Kitsune/utils/kit-plot
@@ -250,11 +250,7 @@ def generate_plot(args, data, metric):
     # Get names/labels and format plot
     title, ylabel, xlabel, filename = plot_labels[metric]
     if not args.no_baseline:
-        ylabel = (
-            "Multiplicative Difference from Baseline ("
-            + baseline
-            + ")\n> 1.0 is faster"
-        )
+        ylabel = "Speedup over kokkos (higher is better)"
     if args.save_dir:
         filename = args.save_dir + "/" + filename
 

--- a/Kitsune/utils/kit-plot
+++ b/Kitsune/utils/kit-plot
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+
+import argparse as ap
+import json
+import matplotlib.pyplot as plt
+import numpy as np
+import os
+import sys
+
+# Despite representing data for different metrics, all the plots are the same
+# type of graph, so they can be generated the same way. However, the graph
+# title, x and y labels, and file names should still be different for each
+# metric. This dictionary stores this information for each metric by using the
+# metric name as the key
+plot_labels = {
+    "compile-time": (
+        "Compilation Time Comparison",
+        "Time (seconds)",
+        "Benchmark Name",
+        "compile-time.png",
+    ),
+    "link-time": (
+        "Link Time Comparison",
+        "Time (seconds)",
+        "Benchmark Name",
+        "link-time.png",
+    ),
+    "total-runtime": (
+        "Code Performance Comparison: Total Runtime",
+        "Total Runtime (seconds)",
+        "Benchmark Name",
+        "total-runtime.png",
+    ),
+    "mean-runtime": (
+        "Code Performance Comparison: Mean Runtime",
+        "Mean Runtime (seconds)",
+        "Benchmark Name",
+        "mean-runtime.png",
+    ),
+    "euler3d-total-runtime": (
+        "Euler3d Kernel Performance Comparison: Total Runtime",
+        "Total Runtime (seconds)",
+        "Kernel Name",
+        "euler3d-kernel-total-rt.png",
+    ),
+    "srad-total-runtime": (
+        "Srad Kernel Performance Comparison: Total Runtime",
+        "Total Runtime (seconds)",
+        "Kernel Name",
+        "srad-kernel-total-rt.png",
+    ),
+    "euler3d-mean-runtime": (
+        "Euler3d Kernel Performance Comparison: Mean Runtime",
+        "Mean Runtime (seconds)",
+        "Kernel Name",
+        "euler3d-kernel-mean-rt.png",
+    ),
+    "srad-mean-runtime": (
+        "Srad Kernel Performance Comparison: Mean Runtime",
+        "Mean Runtime (seconds)",
+        "Kernel Name",
+        "srad-kernel-mean-rt.png",
+    ),
+}
+
+
+# Parse the command line arguments. Returns the parsed object if parsing was
+# successful and will terminate the program with an error message otherwise
+def parse_command_line_args():
+    prog = "plotter"
+    descr = "Generate plots from Kitsune test suite report."
+
+    # TODO: fix help message formatting so that wrapped help message text
+    #       gets indented
+    parser = ap.ArgumentParser(
+        prog=prog, description=descr, formatter_class=ap.RawTextHelpFormatter
+    )
+    parser.add_argument(
+        "-e",
+        "--error-bars",
+        action="store_true",
+        help="Enable error bars for mean-runtime plot. No effect on "
+        "plots for other metrics",
+    )
+    parser.add_argument(
+        "-k",
+        "--kernel-plots",
+        action="store_true",
+        help="When used, plots mean kernel runtime plots for benchmarks "
+        "with multiple kernels: euler3d, srad",
+    )
+    parser.add_argument(
+        "-s",
+        "--save-dir",
+        metavar="<path>",
+        help="Path to directory where you would like to save plots (default:"
+        " save to current directory)",
+    )
+    # TODO: parsing the arguments into a list like this is very clean, but it
+    #       creates a problem if positional argument (report) is put at the
+    #       end of command because it gets wrapped up by nargs choice
+    parser.add_argument(
+        "--benchmarks",
+        metavar="BENCHMARK",
+        nargs="+",
+        type=str,
+        choices=["copy", "euler3d", "raytracer", "saxpy", "srad", "vecadd"],
+        default=["copy", "euler3d", "raytracer", "saxpy", "srad", "vecadd"],
+        help="List of benchmarks to include in plots. "
+        "If bechmarks are not specified, data from all possible "
+        "benchmarks will be plotted\n"
+        "options: copy, euler3d, raytracer, saxpy, srad, vecadd",
+    )
+    parser.add_argument(
+        "--metrics",
+        type=str,
+        metavar="METRIC",
+        nargs="+",
+        choices=["compile-time", "link-time", "total-runtime", "mean-runtime"],
+        default=["compile-time", "link-time", "total-runtime", "mean-runtime"],
+        help="List of metrics to generate plots for. "
+        "If metrics flag is not specified, plots for all possible "
+        "metrics will be generated\n"
+        "options: compile-time, link-time, total-runtime, "
+        "mean-runtime",
+    )
+    parser.add_argument(
+        "--targets",
+        type=str,
+        metavar="TARGET",
+        nargs="+",
+        help="List of targets to include in plots. "
+        "If metrics flag is not specified, plots using all possible "
+        "targets will be generated\n"
+        "options are based on your architecture, use --print-targets "
+        "to print options",
+    )
+    parser.add_argument(
+        "--no-annotate",
+        action="store_false",
+        help="Enable y-value annotations above data bars",
+    )
+    parser.add_argument(
+        "--no-baseline", action="store_true", help="Turn off baseline mode for plots"
+    )
+    parser.add_argument(
+        "--no-metadata",
+        action="store_false",
+        help="Turns metadata caption with date/time and GPU info off",
+    )
+    parser.add_argument(
+        "--print-targets",
+        action="store_true",
+        help="If this flag is used, no plots will be generated. Instead a "
+        "list of targets in provided report will be printed",
+    )
+    parser.add_argument(
+        "report", type=str, metavar="<file>", help="Path to .json report file"
+    )
+
+    return parser.parse_args()
+
+
+def generate_plot(args, data, metric):
+    # These values are used to set up bar positions and width
+    benchmark_names = list(data.values())[0].keys()
+    num_targets = len(data.keys())
+    x = np.arange(len(benchmark_names))
+    width = 0.8 * (1 / num_targets)
+
+    fig, ax = plt.subplots(figsize=(9, 6))
+
+    # Collect baseline data for plots
+    if not args.no_baseline:
+        possible_baselines = ["kokkos-nvidia", "kokkos-amd"]
+        # TODO: I feel like there should be a better way of doing this but if
+        #       there is, I can't think of it right now
+        if possible_baselines[0] in data:
+            baseline = possible_baselines[0]
+        elif possible_baselines[1] in data:
+            baseline = possible_baselines[1]
+        else:
+            sys.exit("Could not find baseline target (kokkos-nvidia or kokkos-amd)")
+        baseline_data = np.array(
+            [data[baseline][k] for k in sorted(data[baseline].keys())]
+        )
+
+    for index, target_name in enumerate(sorted(data.keys())):
+        # This is somewhat convoluted.
+        # The benchmarks are not run in alphabetical order. In practice, this
+        # does not really matter because it only affects the order of the
+        # benchmarks along the x axis. However, the plots look a bit cleaner
+        # when sorted alphabetically
+        annotate_vals = np.array(
+            [data[target_name][k] for k in sorted(data[target_name].keys())]
+        )
+
+        if not args.no_baseline:
+            vals = baseline_data / annotate_vals
+        else:
+            vals = annotate_vals
+
+        if args.no_baseline and metric in args.error_bars_data:
+            error_mins = []
+            error_maxs = []
+            # Similar idea to vals, but the resulting list needs to be split
+            # further since each entry in error_bars is a list of min and max
+            # values for that benchmark. To plot, mins and maxs need to be in
+            # seperate lists, rather than grouped together as in the raw data
+            errs = np.array(
+                [
+                    args.error_bars_data[metric][target_name][k]
+                    for k in sorted(args.error_bars_data[metric][target_name].keys())
+                ]
+            )
+            for i, error_range in enumerate(errs):
+                error_mins.append(vals[i] - error_range[0])
+                error_maxs.append(error_range[1] - vals[i])
+
+            error_ranges = [error_mins, error_maxs]
+        else:
+            error_ranges = None
+
+        # Bars are added to the plot, using index, width, and x to determine
+        # the x position of the center of the bar
+        bars = ax.bar(
+            x + (index + 0.5 * (1 - num_targets)) * width,
+            vals,
+            width,
+            label=target_name,
+            zorder=3,
+            yerr=error_ranges,
+            capsize=5,
+        )
+
+        # Annotate each bar with its y value if enabled
+        if args.no_annotate:
+            for i, bar in enumerate(bars):
+                height = bar.get_height()
+                ax.annotate(
+                    f"{annotate_vals[i]:.2f}",
+                    xy=(bar.get_x() + bar.get_width() / 2, height),
+                    xytext=(0, 3),
+                    textcoords="offset points",
+                    ha="center",
+                    va="bottom",
+                    fontsize=4,
+                )
+
+    # Get names/labels and format plot
+    title, ylabel, xlabel, filename = plot_labels[metric]
+    if not args.no_baseline:
+        ylabel = (
+            "Multiplicative Difference from Baseline ("
+            + baseline
+            + ")\n> 1.0 is faster"
+        )
+    if args.save_dir:
+        filename = args.save_dir + "/" + filename
+
+    ax.set_ylabel(ylabel)
+    ax.set_xlabel(xlabel)
+    ax.set_title(title)
+    ax.set_xticks(x)
+    ax.set_xticklabels(sorted(benchmark_names))
+    ax.legend()
+    ax.grid(axis="y", zorder=1)
+
+    # Add metadata
+    if args.no_metadata:
+        caption = args.report["gpu"]["devices"] + "\n" + args.report["date"]
+        plt.figtext(0, 0, caption, ha="left", va="bottom", color="gray")
+
+    # Clean up the layout and save
+    fig.tight_layout()
+    plt.savefig(filename, dpi=300)
+
+
+def parse_and_plot_benchmark_data(args, json_data):
+    # If no targets are provided, use whatever targets are in the report
+    if not args.targets:
+        args.targets = json_data["targets"]
+
+    if args.error_bars:
+        args.error_bars_data = {
+            "mean-runtime": {},
+            "euler3d-mean-runtime": {},
+            "srad-mean-runtime": {},
+        }
+
+    # Use enabled benchmarks and metrics to make names for kernel metrics
+    # names are of form: benchmark-metric (e.g. euler3d-total-runtime)
+    enabled_kernel_metrics = []
+    if args.kernel_plots:
+        multi_kernel_benchmarks = ["euler3d", "srad"]
+        multi_kernel_metrics = ["total-runtime", "mean-runtime"]
+        for benchmark in [b for b in args.benchmarks if b in multi_kernel_benchmarks]:
+            enabled_kernel_metrics += [
+                (benchmark + "-" + metric)
+                for metric in args.metrics
+                if metric in multi_kernel_metrics
+            ]
+
+    plot_data = {}
+    for metric in args.metrics + enabled_kernel_metrics:
+        plot_data[metric] = {}
+
+    # Collect all data needed for requested plots
+    benchmarks = json_data["tests"]
+    for benchmark_name, benchmark in benchmarks.items():
+        if benchmark_name not in args.benchmarks:
+            continue
+        for target_name, target in benchmark.items():
+            if target_name not in args.targets:
+                continue
+            # Collect data for plots comparing different benchmarks
+            for metric_name in args.metrics:
+                if target_name not in plot_data[metric_name]:
+                    plot_data[metric_name][target_name] = {}
+                    if args.error_bars:
+                        args.error_bars_data["mean-runtime"][target_name] = {}
+
+                if metric_name in target:
+                    val = target[metric_name]
+                elif metric_name == "total-runtime":
+                    val = target["times"]["total"]["total"]
+                elif metric_name == "mean-runtime":
+                    val = target["times"]["total"]["mean"]
+                    if args.error_bars:
+                        rt_min = target["times"]["total"]["min"] / 1000000
+                        rt_max = target["times"]["total"]["max"] / 1000000
+                        args.error_bars_data[metric_name][target_name][
+                            benchmark_name
+                        ] = (rt_min, rt_max)
+                # Convert from microseconds to seconds
+                # TODO: cl arg to set units?
+                plot_data[metric_name][target_name][benchmark_name] = val / 1000000
+
+            # Collect data for plots comparing kernel performance
+            for metric_name in enabled_kernel_metrics:
+                if benchmark_name not in metric_name:
+                    continue
+                if target_name not in plot_data[metric_name]:
+                    plot_data[metric_name][target_name] = {}
+                    if args.error_bars and "mean-runtime" in metric_name:
+                        args.error_bars_data[metric_name][target_name] = {}
+                for kernel_name in target["times"]:
+                    kernel = target["times"][kernel_name]
+                    if kernel["count"] != 1:
+                        if "total-runtime" in metric_name:
+                            val = kernel["total"]
+                        elif "mean-runtime" in metric_name:
+                            val = kernel["mean"]
+                            if args.error_bars:
+                                rt_min = kernel["min"] / 1000000
+                                rt_max = kernel["max"] / 1000000
+                                args.error_bars_data[metric_name][target_name][
+                                    kernel_name
+                                ] = (rt_min, rt_max)
+                        plot_data[metric_name][target_name][kernel_name] = val / 1000000
+
+    # Generate all requested plots
+    for metric, data in plot_data.items():
+        generate_plot(args, data, metric)
+
+    return 0
+
+
+def main():
+    args = parse_command_line_args()
+
+    if not os.path.exists(args.report):
+        sys.exit(f"Could not find report: {args.report}")
+
+    if args.save_dir and not os.path.isdir(args.save_dir):
+        sys.exit(f"Could not find directory: {args.save_dir}")
+
+    if args.error_bars and not args.no_baseline:
+        print(
+            "Warning: Error bars were enabled but it is not possible to "
+            "include error bars on plots scaled by a baseline. Generated "
+            "plots will not have error bars"
+        )
+
+    if args.error_bars and not args.no_annotate:
+        print(
+            "Warning: It is not recommended to include both error bars and "
+            "annotations in one plot since the two features overlap and may "
+            "look somewhat messy"
+        )
+
+    with open(args.report, "r") as file:
+        json_data = json.load(file)
+        args.report = json_data
+
+    if args.print_targets:
+        print(", ".join(json_data["targets"]))
+        return 0
+
+    if not json_data["tests"]:
+        sys.exit("Provided report does have test data")
+
+    parse_and_plot_benchmark_data(args, json_data)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Kit-plot is a utility script that generates plots from a Kitsune test suite report, based on the options provided by the user. There are 3 main options (and several, less significant options) that a user can provide: benchmarks, metrics, and targets. Benchmarks are the benchmarks the test suite runs (vecadd, srad, euler3d, etc.), metrics are the types of data collected by the test suite (compile time, runtime, etc.), and targets refers to the combination of tapir targets and "external" compilers the test suite tests. For each metric, kit-plot will generate a grouped bar chart showing a comparison of the different targets across all benchmarks.